### PR TITLE
Update SunoApi.ts: Hotfix for CLERK_BASE_URL

### DIFF
--- a/src/lib/SunoApi.ts
+++ b/src/lib/SunoApi.ts
@@ -27,7 +27,7 @@ export interface AudioInfo {
 
 class SunoApi {
   private static BASE_URL: string = 'https://studio-api.suno.ai';
-  private static CLERK_BASE_URL: string = 'https://clerk.suno.ai';
+  private static CLERK_BASE_URL: string = 'https://clerk.suno.com';
 
   private readonly client: AxiosInstance;
   private sid?: string;


### PR DESCRIPTION
This is a hotfix for the change of **CLERK_BASE_URL**:
from `clerk.suno.ai` to `clerk.suno.com`