### PR TITLE
Add concat endpoint to "get whole song" from an extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Suno API currently mainly implements the following APIs:
     If no IDs are provided, all music will be returned.
 - `/api/get_limit`: Get quota Info
 - `/api/extend_audio`: Extend audio length
+- `/api/concat`: Generate the whole song from extensions
 ```
 
 For more detailed documentation, please check out the demo site:
@@ -167,6 +168,13 @@ def get_audio_information(audio_ids):
 def get_quota_information():
     url = f"{base_url}/api/get_limit"
     response = requests.get(url)
+    return response.json()
+
+
+def generate_whole_song(clip_id):
+    payloyd = {"clip_id": clip_id}
+    url = f"{base_url}/api/concat"
+    response = requests.post(url, json=payload)
     return response.json()
 
 

--- a/src/app/api/concat/route.ts
+++ b/src/app/api/concat/route.ts
@@ -8,9 +8,9 @@ export async function POST(req: NextRequest) {
   if (req.method === 'POST') {
     try {
       const body = await req.json();
-      const { prompt, tags, title, make_instrumental, wait_audio } = body;
-      if (!prompt || !tags || !title) {
-        return new NextResponse(JSON.stringify({ error: 'Prompt, tags, and title are required' }), {
+      const { clip_id } = body;
+      if (!clip_id) {
+        return new NextResponse(JSON.stringify({ error: 'Clip id is required' }), {
           status: 400,
           headers: {
             'Content-Type': 'application/json',
@@ -18,11 +18,7 @@ export async function POST(req: NextRequest) {
           }
         });
       }
-      const audioInfo = await (await sunoApi).custom_generate(
-        prompt, tags, title,
-        make_instrumental == true,
-        wait_audio == true
-      );
+      const audioInfo = await (await sunoApi).concatenate(clip_id);
       return new NextResponse(JSON.stringify(audioInfo), {
         status: 200,
         headers: {
@@ -31,7 +27,7 @@ export async function POST(req: NextRequest) {
         }
       });
     } catch (error: any) {
-      console.error('Error generating custom audio:', error.response.data);
+      console.error('Error generating concatenating audio:', error.response.data);
       if (error.response.status === 402) {
         return new NextResponse(JSON.stringify({ error: error.response.data.detail }), {
           status: 402,

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -29,6 +29,7 @@ export default function Docs() {
     ids.  If no IDs are provided, all music will be returned.
 - \`/api/get_limit\`: Get quota Info
 - \`/api/extend_audio\`: Extend audio length
+- \`/api/concat\`: Generate the whole song from extensions
 \`\`\`
 
 Feel free to explore the detailed API parameters and conduct tests on this page.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -106,6 +106,7 @@ Suno API currently mainly implements the following APIs:
 - \`/api/get?ids=\`: Get music Info by id, separate multiple id with ",".
 - \`/api/get_limit\`: Get quota Info
 - \`/api/extend_audio\`: Extend audio length
+- \`/api/concat\`: Generate the whole song from extensions
 \`\`\`
 
 For more detailed documentation, please check out the demo site:

--- a/src/lib/SunoApi.ts
+++ b/src/lib/SunoApi.ts
@@ -117,6 +117,29 @@ class SunoApi {
   }
 
   /**
+   * Calls the concatenate endpoint for a clip to generate the whole song.
+   * @param clip_id The ID of the audio clip to concatenate.
+   * @returns A promise that resolves to an AudioInfo object representing the concatenated audio.
+   * @throws Error if the response status is not 200.
+   */
+  public async concatenate(clip_id: string): Promise<AudioInfo> {
+    await this.keepAlive(false);
+    const payload: any = { clip_id: clip_id };
+
+    const response = await this.client.post(
+      `${SunoApi.BASE_URL}/api/generate/concat/v2/`,
+      payload,
+      {
+        timeout: 10000, // 10 seconds timeout
+      },
+    );
+    if (response.status !== 200) {
+      throw new Error("Error response:" + response.statusText);
+    }
+    return response.data;
+  }
+
+  /**
    * Generates custom audio based on provided parameters.
    *
    * @param prompt The text prompt to generate audio from.


### PR DESCRIPTION
**Changes:**
- Added endpoint to "Get the whole song" which given an extension Glip ID will generate a full song including the base tracks and extensions
- Tried to add all documentation but let me know if I've missed anything