### PR TITLE
Add missing null check in get clip.

### DIFF
--- a/src/app/api/clip/route.ts
+++ b/src/app/api/clip/route.ts
@@ -9,6 +9,16 @@ export async function GET(req: NextRequest) {
     try {
       const url = new URL(req.url);
       const clipId = url.searchParams.get('id');
+      if (clipId == null) {
+        return new NextResponse(JSON.stringify({ error: 'Missing parameter id' }), {
+          status: 400,
+          headers: {
+            'Content-Type': 'application/json',
+            ...corsHeaders
+          }
+        });
+      }
+
       const audioInfo = await (await sunoApi).getClip(clipId);
 
       return new NextResponse(JSON.stringify(audioInfo), {


### PR DESCRIPTION
Fixes build error:

```
Type error: Argument of type 'string | null' is not assignable to parameter of type 'string'.
  Type 'null' is not assignable to type 'string'.
```