### PR TITLE
feat: 60 s timeout for custom_generate endpoint to give more time for synchronous song creation on Vercel deployments

### DIFF
--- a/src/app/api/custom_generate/route.ts
+++ b/src/app/api/custom_generate/route.ts
@@ -2,6 +2,7 @@ import { NextResponse, NextRequest } from "next/server";
 import { sunoApi } from "@/lib/SunoApi";
 import { corsHeaders } from "@/lib/utils";
 
+export const maxDuration = 60; // allow longer timeout for wait_audio == true
 export const dynamic = "force-dynamic";
 
 export async function POST(req: NextRequest) {


### PR DESCRIPTION
* increased timeout for custom_generate to 60 s
* prevents many timeouts if wait_audio is set to true on Vercel
* highest possible value to work in all Vercel tiers