### PR TITLE
update chirp v.3.5

### DIFF
--- a/src/lib/SunoApi.ts
+++ b/src/lib/SunoApi.ts
@@ -186,7 +186,7 @@ class SunoApi {
     await this.keepAlive(false);
     const payload: any = {
       make_instrumental: make_instrumental == true,
-      mv: "chirp-v3-0",
+      mv: "chirp-v3-5",
       prompt: "",
     };
     if (isCustom) {


### PR DESCRIPTION
Model 3.5 has become available to all users, so it makes sense to switch to it