### PR TITLE
Adds error message management on generation

### DIFF
--- a/src/lib/SunoApi.ts
+++ b/src/lib/SunoApi.ts
@@ -23,6 +23,7 @@ export interface AudioInfo {
   type?: string;
   tags?: string; // Genre of music.
   duration?: string; // Duration of the audio
+  error_message?: string; // Error message if any
 }
 
 class SunoApi {
@@ -227,7 +228,10 @@ class SunoApi {
         const allCompleted = response.every(
           audio => audio.status === 'streaming' || audio.status === 'complete'
         );
-        if (allCompleted) {
+        const allError = response.every(
+          audio => audio.status === 'error'
+        );
+        if (allCompleted || allError) {
           return response;
         }
         lastResponse = response;
@@ -358,6 +362,7 @@ class SunoApi {
       type: audio.metadata.type,
       tags: audio.metadata.tags,
       duration: audio.metadata.duration_formatted,
+      error_message: audio.metadata.error_message,
     }));
   }
 


### PR DESCRIPTION
Changes:
* Added `error_message` when using `wait_audio`. This is useful for handling errors that cause the `feed` API to continue being used.

For example, if the prompt contains a known artist like Metallica, it will throw an error:
```
"error_message": "Song Description contained artist name: metallica"
```