### PR TITLE
Improved docker compose integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,11 @@ RUN npm run build
 FROM node:lts-alpine
 WORKDIR /app
 COPY package*.json ./
-COPY .env ./
+
+ARG SUNO_COOKIE
+RUN if [ -z "$SUNO_COOKIE" ]; then echo "SUNO_COOKIE is not set" && exit 1; fi
+ENV SUNO_COOKIE=${SUNO_COOKIE}
+
 RUN npm install --only=production
 COPY --from=builder /src/.next ./.next
 EXPOSE 3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,10 @@ version: '3'
 
 services:
   suno-api:
-    build: .
+    build:
+      context: .
+      args:
+        SUNO_COOKIE: ${SUNO_COOKIE}
     volumes:
       - ./public:/app/public
     ports:


### PR DESCRIPTION
Hi there, thanks a bunch for the repo.

This PR makes a small improvement by allowing the `SUNO_COOKIE` variable to be passed via Docker Compose, rather than requiring a `.env` file in the Dockerfile.

The motivation for this is that in Docker Compose you can build from a GitHub repo directly without cloning/submoduling, e.g.,:

```yaml
services:
  suno-api:
    build:
      context: https://github.com/gcui-art/suno-api.git
```

However, this doesn't work because the `Dockerfile` directly copies a `.env` file in the `suno-api` directory, which doesn't exist.

Therefore this PR lets me provide the `SUNO_COOKIE` variable as an argument to the Dockerfile in my top-level `docker-compose.yml`, and thus allow this easier integration:

```yaml
services:
  app:
    ...
  suno-api:
    build:
      context: https://github.com/gcui-art/suno-api.git
      args:
        SUNO_COOKIE: ${SUNO_COOKIE}
```