### PR TITLE
Added negative tags

### DIFF
--- a/src/app/api/custom_generate/route.ts
+++ b/src/app/api/custom_generate/route.ts
@@ -9,12 +9,13 @@ export async function POST(req: NextRequest) {
   if (req.method === 'POST') {
     try {
       const body = await req.json();
-      const { prompt, tags, title, make_instrumental, model, wait_audio } = body;
+      const { prompt, tags, title, make_instrumental, model, wait_audio, negative_tags } = body;
       const audioInfo = await (await sunoApi).custom_generate(
         prompt, tags, title,
         Boolean(make_instrumental),
         model || DEFAULT_MODEL,
-        Boolean(wait_audio)
+        Boolean(wait_audio),
+        negative_tags
       );
       return new NextResponse(JSON.stringify(audioInfo), {
         status: 200,

--- a/src/app/docs/swagger-suno-api.json
+++ b/src/app/docs/swagger-suno-api.json
@@ -138,6 +138,11 @@
                     "description": "Music genre",
                     "example": "pop metal male melancholic"
                   },
+                  "negative_tags": {
+                    "type": "string",
+                    "description": "Negative Music genre",
+                    "example": "female edm techno"
+                  },
                   "title": {
                     "type": "string",
                     "description": "Music title",


### PR DESCRIPTION
Hi!

I noticed that the recently added negative tags are not passed through, so I added them for the custom_generate route. On a local instance, it now passes the negative tags through.

Also, thank you for making this tool, it's super useful. 👍 

resolves #158 