### PR TITLE
Add method(Get clerk latest version) in to lib/SunoApi

### DIFF
--- a/src/lib/SunoApi.ts
+++ b/src/lib/SunoApi.ts
@@ -76,7 +76,6 @@ class SunoApi {
     }
     // Save clerk version ID for auth
     this.clerkVersion = versionListResponse?.data?.['tags']['latest'];
-    console.log(this.clerkVersion)
   }
 
   /**


### PR DESCRIPTION
hi.

Changing the clerk version id in the python package I was using was annoying, so I looked at the structure.

I found that suno AI was using the cleck package's CDN with an address of “clerk.suno.com” and that the address was related to “jsdelivr.com”, so I created a PR for it.

The “clerk.suno.com” CDN also has all the version information for the clerk package, and session authentication succeeds when using the latest version.
![image](https://github.com/user-attachments/assets/e84e0e95-e5e2-459d-b7a2-a006906c3a7c)
