### PR TITLE
Fix extending song

### DIFF
--- a/src/lib/SunoApi.ts
+++ b/src/lib/SunoApi.ts
@@ -368,6 +368,7 @@ class SunoApi {
     title: string = '',
     model?: string
   ): Promise<AudioInfo> {
+    await this.keepAlive(false);
     const response = await this.client.post(
       `${SunoApi.BASE_URL}/api/generate/v2/`,
       {


### PR DESCRIPTION
Was getting errors when trying to extend a song. This would happen when extend song route would be called first before other routes.

Likely same issue as described here:
https://github.com/gcui-art/suno-api/issues/172
https://github.com/gcui-art/suno-api/issues/71