### PR TITLE
Update BASE_URL and implement hCaptcha solving

### DIFF
--- a/src/lib/SunoApi.ts
+++ b/src/lib/SunoApi.ts
@@ -28,7 +28,7 @@ export interface AudioInfo {
 }
 
 class SunoApi {
-  private static BASE_URL: string = 'https://studio-api.suno.ai';
+  private static BASE_URL: string = 'https://studio-api.prod.suno.com';
   private static CLERK_BASE_URL: string = 'https://clerk.suno.com';
   private static JSDELIVR_BASE_URL: string = 'https://data.jsdelivr.com';
 
@@ -237,9 +237,10 @@ class SunoApi {
   ): Promise<AudioInfo[]> {
     await this.keepAlive(false);
     const payload: any = {
-      make_instrumental: make_instrumental == true,
+      make_instrumental: make_instrumental,
       mv: model || DEFAULT_MODEL,
-      prompt: ''
+      prompt: '',
+      generation_type: 'TEXT'
     };
     if (isCustom) {
       payload.tags = tags;


### PR DESCRIPTION
Closes #192, closes #191 

Besides the BASE_URL, Suno also added 'session tokens', but in my testing they aren't actually required. However, if they will eventually be required, the code will be something like this:
```typescript
  /**
   * Get the session token (not to be confused with session ID) and save it for later use.
   */
  private async getSessionToken() {
    const tokenResponse = await this.client.post(
      'https://studio-api.prod.suno.com/api/user/create_session_id/',
      {
        session_properties: JSON.stringify({ deviceId: uuidv4() }),
        session_type: 1
      }
    );
    logger.info(tokenResponse.data.session_id);
    this.sessionToken = tokenResponse.data.session_id;
  } // metadata: { create_session_token: this.sessionToken }
```