### PR TITLE
fix for 401 error in 'get_limit' and 'get' request

### DIFF
--- a/src/lib/SunoApi.ts
+++ b/src/lib/SunoApi.ts
@@ -80,7 +80,9 @@ class SunoApi {
       );
     }
     // Save clerk version ID for auth
-    this.clerkVersion = versionListResponse?.data?.['tags']['latest'];
+    // this.clerkVersion = versionListResponse?.data?.['tags']['latest'];
+    // Use a Clerk version released before fraud detection was implemented
+    this.clerkVersion = "5.34.0";
   }
 
   /**


### PR DESCRIPTION
Use a Clerk version released before fraud detection was implemented