### PR TITLE
fix(readme): remove the extra quotation mark in the <h1> tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <h1 align="center"">
+  <h1 align="center">
       Suno AI API
   </h1>
   <p>Use API to call the music generation AI of Suno.ai and easily integrate it into agents like GPTs.</p>


### PR DESCRIPTION
An extra quotation mark in the <h1"> align attribute was causing syntax issues in the README. This commit corrects that to ensure valid HTML rendering.