### PR TITLE
feat: Rewrite CAPTCHA handling (v2) + async concurrency support

### DIFF
--- a/CHANGELOG_V2_CAPTCHA.md
+++ b/CHANGELOG_V2_CAPTCHA.md
@@ -1,0 +1,90 @@
+# V2 — CAPTCHA Handling Rewrite
+
+## Problem
+
+The original CAPTCHA handling in `SunoApi.ts` used hardcoded selectors (`.custom-textarea`) that broke when Suno updated their UI. This caused:
+
+1. `TimeoutError: Timeout 30000ms exceeded` waiting for `.custom-textarea`
+2. Massive log spam from polling loops (`"Sleeping for 0.25 seconds"` hundreds of times)
+3. Unhandled promise rejections when the captcha-solver promise failed
+4. No way to debug what the Suno page actually looked like
+
+## Changes
+
+### `src/lib/SunoApi.ts`
+
+#### New Helper Methods
+
+| Method | Purpose |
+|---|---|
+| `saveDebugSnapshot(page, label, requestLog?)` | Saves HTML, screenshot, request log, and frame list to `debug/` folder |
+| `waitForCaptchaFrame(page, timeout?)` | Detects hCaptcha, reCAPTCHA, Cloudflare Turnstile, or Arkose/FunCaptcha iframes |
+| `waitForAnyVisibleLocator(page, selectors, timeout?)` | Polls multiple CSS selectors, returns first visible. Uses raw `setTimeout(500)` to avoid log spam |
+
+#### Rewritten `getCaptcha()`
+
+The entire method was rewritten with numbered debug snapshots at every step:
+
+| Step | Snapshot | Description |
+|---|---|---|
+| 1 | `01-page-loaded` | HTML + screenshot after navigating to `suno.com/create` |
+| 2 | `02-interactive-elements.log` | All `<button>`, `<textarea>`, `<input>`, `[contenteditable]` elements with full attributes |
+| 3 | `03-no-prompt-input` | Saved only if no prompt input was found |
+| 4 | `04-no-create-button` | Saved only if no Create button was found |
+| 5 | `05-after-create-click` | HTML + screenshot + request log after clicking Create |
+| 6 | `06-after-second-click` | Same, after retry if first click didn't trigger CAPTCHA |
+| 7 | `07-no-captcha-final` | Final state if no CAPTCHA appeared and generation didn't proceed |
+| 8 | `08-unsupported-captcha` | If a non-hCaptcha provider was detected |
+
+#### Key Improvements
+
+- **Fallback selectors**: 10 selectors for prompt input, 8 for Create button
+- **Popup dismissal**: Automatically closes modals/banners before interacting
+- **Interactive element discovery**: Logs every interactive element on the page to help identify new selectors
+- **Route interception before click**: Sets up `page.route('**/api/generate/v2/**')` before clicking Create so we never miss the generate call
+- **Retry logic**: Clicks Create a second time if no CAPTCHA appears after the first click
+- **Race condition handling**: Races between token interception and timeout, correctly handles generation proceeding without CAPTCHA
+- **Error propagation**: Captcha solver errors are properly wired to the outer token promise via `rejectOuter()`
+
+### `src/lib/utils.ts`
+
+#### Updated `sleep()`
+
+- Only logs calls ≥ 1 second to prevent polling log spam
+
+#### Updated `waitForRequests()`
+
+- Detects **6 URL patterns** across 4 CAPTCHA providers:
+  - `img*.hcaptcha.com` + `*.hcaptcha.com/captcha/`
+  - `www.google.com/recaptcha/` + `www.gstatic.com/recaptcha/`
+  - `challenges.cloudflare.com/`
+  - `*.arkoselabs.com/`
+- Timeout increased from 60s → 120s
+- Error message updated: "No CAPTCHA image/resource requests detected within 2 minutes"
+
+## Debug Output
+
+After running a request, check the `debug/` folder:
+
+```
+debug/
+├── 01-page-loaded.html
+├── 01-page-loaded.png
+├── 01-page-loaded-frames.log
+├── 01-page-loaded-requests.log
+├── 02-interactive-elements.log       ← Most valuable for selector debugging
+├── 05-after-create-click.html
+├── 05-after-create-click.png
+├── 05-after-create-click-requests.log
+├── 05-after-create-click-frames.log
+└── ...
+```
+
+## How to Debug
+
+1. Run `npm run dev`
+2. Hit `/api/custom_generate` with a POST request
+3. Check `debug/02-interactive-elements.log` — every interactive element on the Suno page with full attributes
+4. Check screenshots to see what the page actually looks like
+5. Check request logs to see what URLs were loaded
+6. Adjust selectors in `promptSelectors` and `buttonSelectors` arrays if Suno changed their UI again

--- a/CHANGELOG_V3_CONCURRENCY.md
+++ b/CHANGELOG_V3_CONCURRENCY.md
@@ -1,0 +1,144 @@
+# V3 — Async Concurrency Support
+
+## Problem
+
+The SunoApi class was not safe for concurrent requests. When multiple API calls hit the server simultaneously:
+
+1. **Token refresh race**: Multiple calls to `keepAlive()` would all refresh the token at the same time, hammering the Clerk API
+2. **Browser collision**: Multiple calls to `getCaptcha()` would each launch a separate browser, wasting resources
+3. **No request tracking**: Logs from concurrent requests were interleaved with no way to tell them apart
+4. **No concurrency limit**: Unlimited parallel generation requests could overwhelm the Suno API
+
+## Changes
+
+### `src/lib/utils.ts` — New Concurrency Primitives
+
+#### `AsyncMutex`
+
+A simple async mutual exclusion lock. Only one holder at a time; others queue up.
+
+```typescript
+const mutex = new AsyncMutex();
+
+const release = await mutex.acquire();
+try {
+  // Critical section — only one caller at a time
+} finally {
+  release();
+}
+```
+
+Properties:
+- `isLocked: boolean` — Whether the mutex is currently held
+- `queueLength: number` — How many callers are waiting
+
+#### `AsyncSemaphore`
+
+An async semaphore that allows up to N concurrent holders.
+
+```typescript
+const semaphore = new AsyncSemaphore(3); // max 3 concurrent
+
+const release = await semaphore.acquire();
+try {
+  // Up to 3 callers can be here simultaneously
+} finally {
+  release();
+}
+```
+
+Properties:
+- `activeCount: number` — How many slots are currently in use
+- `waitingCount: number` — How many callers are queued
+
+### `src/lib/SunoApi.ts` — Concurrency Integration
+
+#### New Instance Fields
+
+| Field | Type | Purpose |
+|---|---|---|
+| `keepAliveMutex` | `AsyncMutex` | Serializes token refresh |
+| `captchaMutex` | `AsyncMutex` | Serializes CAPTCHA browser sessions |
+| `requestSemaphore` | `AsyncSemaphore` | Limits concurrent generation requests |
+| `lastKeepAliveTime` | `number` | Timestamp of last successful token refresh |
+| `requestCounter` | `number` | Auto-incrementing request ID for log tracing |
+| `KEEPALIVE_COOLDOWN_MS` | `30000` | Skip refresh if token was refreshed within 30s |
+
+#### Updated `keepAlive()`
+
+- **Fast-path skip**: If token was refreshed within `KEEPALIVE_COOLDOWN_MS` (30s), returns immediately without acquiring the mutex
+- **Mutex-protected refresh**: Only one caller actually refreshes the token
+- **Double-check pattern**: After acquiring the mutex, re-checks the cooldown (another caller may have refreshed while waiting)
+
+```
+Request A ──► keepAlive() ──► acquires mutex ──► refreshes token ──► releases
+Request B ──► keepAlive() ──► waits on mutex ──► checks cooldown ──► skips (recent) ──► releases
+Request C ──► keepAlive() ──► cooldown check ──► skips immediately (fast-path)
+```
+
+#### Updated `getCaptcha()`
+
+- **Mutex-serialized**: Only one browser session at a time
+- **Re-check after lock**: After acquiring the mutex, re-checks `captchaRequired()` — a previous caller may have solved it
+- **Queue visibility**: Logs how many requests are waiting when the mutex is contended
+
+```
+Request A ──► getCaptcha() ──► acquires mutex ──► launches browser ──► solves CAPTCHA ──► releases
+Request B ──► getCaptcha() ──► waits on mutex ──► re-checks ──► CAPTCHA no longer needed ──► returns null
+```
+
+#### Updated `generateSongs()`
+
+- **Semaphore-limited**: Controlled by `CONCURRENT_LIMIT` env var (default: 3)
+- **Request IDs**: Each request gets `[req-N]` prefix in logs for traceability
+- **Slot logging**: Logs active/waiting counts when acquiring a slot
+
+```
+[req-1] Acquired slot (active: 1, waiting: 0)
+[req-2] Acquired slot (active: 2, waiting: 0)
+[req-3] Acquired slot (active: 3, waiting: 0)
+[req-4] ...waiting... (semaphore full)
+[req-1] Released slot
+[req-4] Acquired slot (active: 3, waiting: 0)
+```
+
+### `.env` — New Configuration
+
+```env
+# Max concurrent generation requests (default: 3)
+CONCURRENT_LIMIT=3
+```
+
+## Concurrency Flow (5 simultaneous requests)
+
+```
+Time ──────────────────────────────────────────────────────►
+
+req-1: ├─keepAlive(refresh)─┤─getCaptcha(null)─┤─generate──────────┤ done
+req-2: ├─keepAlive(skip)────┤─getCaptcha(null)─┤─generate──────────┤ done
+req-3: ├─keepAlive(skip)────┤─getCaptcha(null)─┤─generate──────────┤ done
+req-4: ├─keepAlive(skip)────┤─getCaptcha(null)─┤──wait──┤─generate─┤ done
+req-5: ├─keepAlive(skip)────┤─getCaptcha(null)─┤──wait──┤─generate─┤ done
+                                                ▲
+                                          semaphore limit (3)
+```
+
+## Response Format
+
+Each request still returns **2 audio clips** (Suno platform behavior). So 5 concurrent requests = 10 total audio clips.
+
+```json
+// Single request response
+[
+  { "id": "abc-123", "title": "My Song", "status": "submitted" },
+  { "id": "def-456", "title": "My Song", "status": "submitted" }
+]
+```
+
+## How to Use
+
+1. Set `CONCURRENT_LIMIT=3` in `.env` (or any number you want)
+2. Run `npm run dev`
+3. Fire multiple POST requests to `/api/custom_generate` simultaneously
+4. Each request will be queued and processed in order, with at most `CONCURRENT_LIMIT` running at once
+5. Logs will show `[req-N]` prefixes so you can trace each request

--- a/src/lib/SunoApi.ts
+++ b/src/lib/SunoApi.ts
@@ -656,11 +656,16 @@ class SunoApi {
       const frame = page.frameLocator('iframe[title*="hCaptcha"]');
       const challenge = frame.locator('.challenge-container');
       try {
-        let wait = true;
+        // First iteration: challenge is already loaded (images already fetched), skip waitForRequests.
+        // Subsequent iterations: wait for the new challenge images to load after each submission.
+        let wait = false;
         while (true) {
           if (wait)
             await waitForRequests(page, controller.signal);
-          const drag = (await challenge.locator('.prompt-text').first().innerText()).toLowerCase().includes('drag');
+          // Wait for the challenge container to be fully rendered before interacting
+          await challenge.waitFor({ state: 'visible', timeout: 60000 });
+          const promptText = await challenge.locator('.prompt-text').first().innerText({ timeout: 15000 }).catch(() => '');
+          const drag = promptText.toLowerCase().includes('drag');
           let captcha: any;
           for (let j = 0; j < 3; j++) {
             try {
@@ -709,6 +714,7 @@ class SunoApi {
               logger.info(data);
               await this.click(challenge, { x: +data.x, y: +data.y });
             }
+            wait = true; // Wait for new challenge images after submit
           }
           this.click(frame.locator('.button-submit')).catch(e => {
             if (e.message.includes('viewport'))

--- a/src/lib/SunoApi.ts
+++ b/src/lib/SunoApi.ts
@@ -2,7 +2,7 @@ import axios, { AxiosInstance } from 'axios';
 import UserAgent from 'user-agents';
 import pino from 'pino';
 import yn from 'yn';
-import { isPage, sleep, waitForRequests } from '@/lib/utils';
+import { isPage, sleep, waitForRequests, AsyncMutex, AsyncSemaphore } from '@/lib/utils';
 import * as cookie from 'cookie';
 import { randomUUID } from 'node:crypto';
 import { Solver } from '@2captcha/captcha-solver';
@@ -81,6 +81,16 @@ class SunoApi {
   private solver = new Solver(process.env.TWOCAPTCHA_KEY + '');
   private ghostCursorEnabled = yn(process.env.BROWSER_GHOST_CURSOR, { default: false });
   private cursor?: Cursor;
+
+  // Concurrency control
+  private keepAliveMutex = new AsyncMutex();
+  private captchaMutex = new AsyncMutex();
+  private requestSemaphore = new AsyncSemaphore(
+    parseInt(process.env.CONCURRENT_LIMIT || '3', 10)
+  );
+  private lastKeepAliveTime = 0;
+  private static readonly KEEPALIVE_COOLDOWN_MS = 30_000; // skip refresh if < 30s ago
+  private requestCounter = 0;
 
   constructor(cookies: string) {
     this.userAgent = new UserAgent(/Macintosh/).random().toString(); // Usually Mac systems get less amount of CAPTCHAs
@@ -168,25 +178,45 @@ class SunoApi {
 
   /**
    * Keep the session alive.
+   * Uses a mutex to prevent concurrent token refreshes, and a cooldown
+   * so rapid back-to-back calls skip redundant refreshes.
    * @param isWait Indicates if the method should wait for the session to be fully renewed before returning.
    */
   public async keepAlive(isWait?: boolean): Promise<void> {
     if (!this.sid) {
       throw new Error('Session ID is not set. Cannot renew token.');
     }
-    // URL to renew session token
-    const renewUrl = `${SunoApi.CLERK_BASE_URL}/v1/client/sessions/${this.sid}/tokens?_is_native=true&_clerk_js_version=${SunoApi.CLERK_VERSION}`;
-    // Renew session token
-    logger.info('KeepAlive...\n');
-    const renewResponse = await this.client.post(renewUrl, {}, {
-      headers: { Authorization: this.cookies.__client }
-    });
-    if (isWait) {
-      await sleep(1, 2);
+
+    // Fast path: skip if recently refreshed (avoids mutex contention)
+    const now = Date.now();
+    if (this.currentToken && now - this.lastKeepAliveTime < SunoApi.KEEPALIVE_COOLDOWN_MS) {
+      return;
     }
-    const newToken = renewResponse.data.jwt;
-    // Update Authorization field in request header with the new JWT token
-    this.currentToken = newToken;
+
+    const release = await this.keepAliveMutex.acquire();
+    try {
+      // Double-check after acquiring lock (another caller may have refreshed while we waited)
+      if (this.currentToken && Date.now() - this.lastKeepAliveTime < SunoApi.KEEPALIVE_COOLDOWN_MS) {
+        return;
+      }
+
+      // URL to renew session token
+      const renewUrl = `${SunoApi.CLERK_BASE_URL}/v1/client/sessions/${this.sid}/tokens?_is_native=true&_clerk_js_version=${SunoApi.CLERK_VERSION}`;
+      // Renew session token
+      logger.info('KeepAlive...\n');
+      const renewResponse = await this.client.post(renewUrl, {}, {
+        headers: { Authorization: this.cookies.__client }
+      });
+      if (isWait) {
+        await sleep(1, 2);
+      }
+      const newToken = renewResponse.data.jwt;
+      // Update Authorization field in request header with the new JWT token
+      this.currentToken = newToken;
+      this.lastKeepAliveTime = Date.now();
+    } finally {
+      release();
+    }
   }
 
   /**
@@ -301,40 +331,328 @@ class SunoApi {
   }
 
   /**
-   * Checks for CAPTCHA verification and solves the CAPTCHA if needed
+   * Returns the first visible locator from a list of selectors.
+   * Uses a raw delay to avoid log spam from the sleep() helper.
+   */
+  private async waitForAnyVisibleLocator(page: Page, selectors: string[], timeout = 30000): Promise<Locator | null> {
+    const start = Date.now();
+    while (Date.now() - start < timeout) {
+      for (const selector of selectors) {
+        const locator = page.locator(selector).first();
+        const visible = await locator.isVisible().catch(() => false);
+        if (visible)
+          return locator;
+      }
+      await new Promise(r => setTimeout(r, 500));
+    }
+    return null;
+  }
+
+  /**
+   * Saves full-page HTML, screenshot, and request log into the debug/ folder.
+   */
+  private async saveDebugSnapshot(page: Page, label: string, requestLog?: string[]): Promise<void> {
+    const debugDir = path.join(process.cwd(), 'debug');
+    try {
+      await fs.mkdir(debugDir, { recursive: true });
+      await fs.writeFile(path.join(debugDir, `${label}.html`), await page.content());
+      await page.screenshot({ path: path.join(debugDir, `${label}.png`), fullPage: true });
+      if (requestLog) {
+        await fs.writeFile(path.join(debugDir, `${label}-requests.log`), requestLog.join('\n'));
+      }
+      // List all frames
+      const frameUrls = page.frames().map(f => f.url());
+      await fs.writeFile(path.join(debugDir, `${label}-frames.log`), frameUrls.join('\n'));
+      logger.info(`Debug snapshot saved: debug/${label}.*`);
+    } catch (e: any) {
+      logger.warn(`Failed to save debug snapshot "${label}": ${e.message}`);
+    }
+  }
+
+  /**
+   * Wait for any CAPTCHA iframe to appear on the page.
+   * Detects hCaptcha, reCAPTCHA, Cloudflare Turnstile, Arkose/FunCaptcha.
+   * @returns The detected captcha type or null if none found.
+   */
+  private async waitForCaptchaFrame(page: Page, timeout = 30000): Promise<'hcaptcha' | 'recaptcha' | 'turnstile' | 'arkose' | null> {
+    const start = Date.now();
+    while (Date.now() - start < timeout) {
+      const frames = page.frames();
+      for (const frame of frames) {
+        const url = frame.url().toLowerCase();
+        if (url.includes('hcaptcha.com')) return 'hcaptcha';
+        if (url.includes('google.com/recaptcha') || url.includes('recaptcha')) return 'recaptcha';
+        if (url.includes('challenges.cloudflare.com') || url.includes('turnstile')) return 'turnstile';
+        if (url.includes('arkoselabs.com') || url.includes('funcaptcha')) return 'arkose';
+      }
+      // Also check for captcha iframes by title attribute
+      for (const selector of [
+        'iframe[title*="hCaptcha" i]',
+        'iframe[title*="recaptcha" i]',
+        'iframe[title*="Cloudflare" i]',
+        'iframe[title*="challenge" i]',
+        'iframe[src*="hcaptcha" i]',
+        'iframe[src*="recaptcha" i]',
+        'iframe[src*="turnstile" i]',
+        'iframe[src*="arkoselabs" i]',
+      ]) {
+        const exists = await page.locator(selector).first().isVisible().catch(() => false);
+        if (exists) {
+          if (selector.includes('hCaptcha') || selector.includes('hcaptcha')) return 'hcaptcha';
+          if (selector.includes('recaptcha')) return 'recaptcha';
+          if (selector.includes('Cloudflare') || selector.includes('turnstile')) return 'turnstile';
+          if (selector.includes('arkoselabs')) return 'arkose';
+        }
+      }
+      await new Promise(r => setTimeout(r, 500));
+    }
+    return null;
+  }
+
+  /**
+   * Checks for CAPTCHA verification and solves the CAPTCHA if needed.
+   * v2: Saves debug snapshots (HTML, screenshots, request & frame logs) into debug/ folder
+   * at every important step so you can inspect the actual page state.
+   * Serialized via captchaMutex so only one browser session runs at a time.
    * @returns {string|null} hCaptcha token. If no verification is required, returns null
    */
   public async getCaptcha(): Promise<string|null> {
     if (!await this.captchaRequired())
       return null;
 
-    logger.info('CAPTCHA required. Launching browser...')
+    // Serialize CAPTCHA solving — only one browser session at a time
+    const releaseCaptcha = await this.captchaMutex.acquire();
+    if (this.captchaMutex.queueLength > 0)
+      logger.info(`CAPTCHA mutex: ${this.captchaMutex.queueLength} request(s) waiting`);
+
+    try {
+      // Re-check after acquiring the lock — a previous caller may have solved it
+      if (!await this.captchaRequired())
+        return null;
+
+      return await this._solveCaptcha();
+    } finally {
+      releaseCaptcha();
+    }
+  }
+
+  /**
+   * Internal CAPTCHA-solving logic (called under captchaMutex).
+   */
+  private async _solveCaptcha(): Promise<string|null> {
+
+    logger.info('CAPTCHA required. Launching browser...');
     const browser = await this.launchBrowser();
     const page = await browser.newPage();
-    await page.goto('https://suno.com/create', { referer: 'https://www.google.com/', waitUntil: 'domcontentloaded', timeout: 0 });
+
+    // Collect ALL network requests for debugging
+    const requestLog: string[] = [];
+    page.on('request', (req: any) => {
+      const url: string = req.url();
+      if (!url.startsWith('data:') && !url.endsWith('.woff2') && !url.endsWith('.woff'))
+        requestLog.push(`[${new Date().toISOString()}] ${req.method()} ${url}`);
+    });
+
+    await page.goto('https://suno.com/create', {
+      referer: 'https://www.google.com/',
+      waitUntil: 'domcontentloaded',
+      timeout: 60000
+    });
 
     logger.info('Waiting for Suno interface to load');
-    // await page.locator('.react-aria-GridList').waitFor({ timeout: 60000 });
-    await page.waitForResponse('**/api/project/**\\?**', { timeout: 60000 }); // wait for song list API call
+    // Wait for the page to actually settle
+    try {
+      await page.waitForLoadState('networkidle', { timeout: 30000 });
+    } catch {
+      logger.warn('Network did not reach idle state within 30s; continuing');
+    }
+
+    // --- Debug snapshot: page loaded ---
+    await this.saveDebugSnapshot(page, '01-page-loaded', requestLog);
 
     if (this.ghostCursorEnabled)
       this.cursor = await createCursor(page);
-    
-    logger.info('Triggering the CAPTCHA');
+
+    // Close any popups / modals / banners
+    for (const closeSelector of [
+      'button[aria-label="Close"]',
+      '[aria-label="close"]',
+      '[aria-label="Dismiss"]',
+      'button:has-text("Got it")',
+      'button:has-text("Accept")',
+      'button:has-text("OK")',
+    ]) {
+      try {
+        const closeBtn = page.locator(closeSelector).first();
+        if (await closeBtn.isVisible({ timeout: 500 }).catch(() => false)) {
+          await closeBtn.click({ timeout: 1000 });
+          logger.info(`Closed popup via ${closeSelector}`);
+        }
+      } catch {}
+    }
+
+    // --- Discover the actual page structure ---
+    // Log all interactive elements on the page for debugging
     try {
-      await page.getByLabel('Close').click({ timeout: 2000 }); // close all popups
-      // await this.click(page, { x: 318, y: 13 });
-    } catch(e) {}
+      const interactiveElements = await page.evaluate(() => {
+        const elements: string[] = [];
+        document.querySelectorAll('button, textarea, input, [contenteditable], [role="textbox"], [role="button"]').forEach((el) => {
+          const tag = el.tagName.toLowerCase();
+          const attrs = Array.from(el.attributes).map(a => `${a.name}="${a.value}"`).join(' ');
+          const text = (el as HTMLElement).innerText?.slice(0, 50) || '';
+          elements.push(`<${tag} ${attrs}> ${text}`);
+        });
+        return elements;
+      });
+      const debugDir = path.join(process.cwd(), 'debug');
+      await fs.mkdir(debugDir, { recursive: true });
+      await fs.writeFile(path.join(debugDir, '02-interactive-elements.log'), interactiveElements.join('\n'));
+      logger.info(`Found ${interactiveElements.length} interactive elements (see debug/02-interactive-elements.log)`);
+    } catch (e: any) {
+      logger.warn(`Failed to enumerate interactive elements: ${e.message}`);
+    }
 
-    const textarea = page.locator('.custom-textarea');
-    await this.click(textarea);
-    await textarea.pressSequentially('Lorem ipsum', { delay: 80 });
+    // --- Step 1: Find and fill prompt input ---
+    logger.info('Looking for prompt input');
+    const promptSelectors = [
+      '.custom-textarea',
+      'textarea[placeholder*="lyrics" i]',
+      'textarea[placeholder*="describe" i]',
+      'textarea[placeholder*="song" i]',
+      'textarea[placeholder*="prompt" i]',
+      'textarea',
+      '[contenteditable="true"][role="textbox"]',
+      '[contenteditable="true"]',
+      'div[role="textbox"]',
+      'input[type="text"]',
+    ];
+    const promptInput = await this.waitForAnyVisibleLocator(page, promptSelectors, 15000);
+    if (promptInput) {
+      const desc = await promptInput.evaluate((el: Element) =>
+        `${el.tagName}.${el.className} placeholder="${el.getAttribute('placeholder') || ''}"`
+      ).catch(() => 'unknown');
+      logger.info(`Found prompt input: ${desc}`);
+      await this.click(promptInput);
+      await new Promise(r => setTimeout(r, 300));
+      await promptInput.pressSequentially('Lorem ipsum dolor sit amet', { delay: 60 });
+    } else {
+      logger.warn('No prompt input found anywhere on page');
+      await this.saveDebugSnapshot(page, '03-no-prompt-input', requestLog);
+    }
 
-    const button = page.locator('button[aria-label="Create"]').locator('div.flex');
-    this.click(button);
+    // --- Step 2: Find and click the Create / Generate button ---
+    logger.info('Looking for Create/Generate button');
+    const buttonSelectors = [
+      'button[aria-label="Create"]',
+      'button:has-text("Create")',
+      '[role="button"]:has-text("Create")',
+      'button[type="submit"]',
+      'button:has-text("Generate")',
+      '[role="button"]:has-text("Generate")',
+      'button:has-text("Make a song")',
+      'button:has-text("Submit")',
+    ];
+    const button = await this.waitForAnyVisibleLocator(page, buttonSelectors, 15000);
+    if (!button) {
+      logger.error('Could not find any Create/Generate button');
+      await this.saveDebugSnapshot(page, '04-no-create-button', requestLog);
+      await browser.browser()?.close();
+      throw new Error(
+        'Could not find a Create/Generate button on the page. '
+        + 'The Suno UI may have changed. Check the debug/ folder for HTML snapshots and screenshots.'
+      );
+    }
 
+    const buttonInfo = await button.evaluate((el: Element) =>
+      `<${el.tagName} class="${el.className}" aria-label="${el.getAttribute('aria-label') || ''}">${(el as HTMLElement).innerText?.slice(0, 40)}`
+    ).catch(() => 'unknown');
+    logger.info(`Found button: ${buttonInfo}`);
+
+    // Set up route interception BEFORE clicking Create so we don't miss the generate call
     const controller = new AbortController();
-    new Promise<void>(async (resolve, reject) => {
+    let rejectOuter: (err: any) => void = () => {};
+    let resolveOuter: (token: string | null) => void = () => {};
+
+    const tokenPromise = new Promise<string | null>((resolve, reject) => {
+      resolveOuter = resolve;
+      rejectOuter = reject;
+
+      // Intercept the generate API call to extract the captcha token
+      page.route('**/api/generate/v2/**', async (route: any) => {
+        try {
+          logger.info('Generate API call intercepted! Extracting token and closing browser');
+          const request = route.request();
+          this.currentToken = request.headers().authorization?.split('Bearer ').pop();
+          const postData = request.postDataJSON();
+          route.abort();
+          controller.abort();
+          browser.browser()?.close();
+          resolve(postData?.token || null);
+        } catch (err) {
+          reject(err);
+        }
+      });
+    });
+
+    // Click the button to trigger generation (and hopefully a CAPTCHA)
+    logger.info('Clicking Create button');
+    await this.click(button);
+    await new Promise(r => setTimeout(r, 3000)); // wait for CAPTCHA to appear
+
+    // --- Debug snapshot: after Create click ---
+    await this.saveDebugSnapshot(page, '05-after-create-click', requestLog);
+
+    // --- Step 3: Detect what CAPTCHA appeared ---
+    logger.info('Waiting for CAPTCHA challenge to appear...');
+    let captchaType = await this.waitForCaptchaFrame(page, 15000);
+
+    if (!captchaType) {
+      // Try clicking the button again — sometimes the first click is swallowed
+      logger.warn('No CAPTCHA detected after first click. Retrying...');
+      await this.click(button);
+      await new Promise(r => setTimeout(r, 5000));
+      await this.saveDebugSnapshot(page, '06-after-second-click', requestLog);
+      captchaType = await this.waitForCaptchaFrame(page, 20000);
+    }
+
+    if (!captchaType) {
+      // Check if the generate API was called without a CAPTCHA (maybe CAPTCHA wasn't needed after all)
+      logger.warn('No CAPTCHA iframe found. Checking if generation proceeded without CAPTCHA...');
+      // Give the tokenPromise a chance to resolve
+      const raceResult = await Promise.race([
+        tokenPromise.then(t => ({ type: 'token' as const, value: t })),
+        new Promise<{ type: 'timeout' }>(r => setTimeout(() => r({ type: 'timeout' }), 10000)),
+      ]);
+      if (raceResult.type === 'token') {
+        logger.info('Generation proceeded without visible CAPTCHA');
+        return raceResult.value;
+      }
+
+      // Truly no CAPTCHA and no generation
+      await this.saveDebugSnapshot(page, '07-no-captcha-final', requestLog);
+      await browser.browser()?.close();
+      throw new Error(
+        'No CAPTCHA appeared and generation did not proceed. '
+        + 'The Suno UI may have changed significantly. '
+        + 'Check the debug/ folder for HTML, screenshots, interactive elements, and request logs.'
+      );
+    }
+
+    logger.info(`Detected CAPTCHA type: ${captchaType}`);
+
+    if (captchaType !== 'hcaptcha') {
+      // We only support hCaptcha via 2Captcha right now
+      await this.saveDebugSnapshot(page, '08-unsupported-captcha', requestLog);
+      await browser.browser()?.close();
+      throw new Error(
+        `Detected CAPTCHA type "${captchaType}" which is not currently supported. `
+        + 'Only hCaptcha is supported via 2Captcha. Check debug/ folder for details.'
+      );
+    }
+
+    // --- Step 4: Solve hCaptcha challenges in a loop ---
+    logger.info('Starting hCaptcha solving loop');
+    const captchaSolverPromise = new Promise<void>(async (resolve, reject) => {
       const frame = page.frameLocator('iframe[title*="hCaptcha"]');
       const challenge = frame.locator('.challenge-container');
       try {
@@ -344,7 +662,7 @@ class SunoApi {
             await waitForRequests(page, controller.signal);
           const drag = (await challenge.locator('.prompt-text').first().innerText()).toLowerCase().includes('drag');
           let captcha: any;
-          for (let j = 0; j < 3; j++) { // try several times because sometimes 2Captcha could return an error
+          for (let j = 0; j < 3; j++) {
             try {
               logger.info('Sending the CAPTCHA to 2Captcha');
               const payload: paramsCoordinates = {
@@ -352,20 +670,19 @@ class SunoApi {
                 lang: process.env.BROWSER_LOCALE
               };
               if (drag) {
-                // Say to the worker that he needs to click
                 payload.textinstructions = 'CLICK on the shapes at their edge or center as shown above—please be precise!';
                 payload.imginstructions = (await fs.readFile(path.join(process.cwd(), 'public', 'drag-instructions.jpg'))).toString('base64');
               }
               captcha = await this.solver.coordinates(payload);
               break;
-            } catch(err: any) {
+            } catch (err: any) {
               logger.info(err.message);
-              if (j != 2)
+              if (j !== 2)
                 logger.info('Retrying...');
               else
                 throw err;
             }
-          } 
+          }
           if (drag) {
             const challengeBox = await challenge.boundingBox();
             if (challengeBox == null)
@@ -378,11 +695,11 @@ class SunoApi {
             }
             for (let i = 0; i < captcha.data.length; i += 2) {
               const data1 = captcha.data[i];
-              const data2 = captcha.data[i+1];
+              const data2 = captcha.data[i + 1];
               logger.info(JSON.stringify(data1) + JSON.stringify(data2));
               await page.mouse.move(challengeBox.x + +data1.x, challengeBox.y + +data1.y);
               await page.mouse.down();
-              await sleep(1.1); // wait for the piece to be 'unlocked'
+              await sleep(1.1);
               await page.mouse.move(challengeBox.x + +data2.x, challengeBox.y + +data2.y, { steps: 30 });
               await page.mouse.up();
             }
@@ -391,41 +708,33 @@ class SunoApi {
             for (const data of captcha.data) {
               logger.info(data);
               await this.click(challenge, { x: +data.x, y: +data.y });
-            };
+            }
           }
           this.click(frame.locator('.button-submit')).catch(e => {
-            if (e.message.includes('viewport')) // when hCaptcha window has been closed due to inactivity,
-              this.click(button); // click the Create button again to trigger the CAPTCHA
+            if (e.message.includes('viewport'))
+              this.click(button);
             else
               throw e;
           });
         }
-      } catch(e: any) {
-        if (e.message.includes('been closed') // catch error when closing the browser
-          || e.message == 'AbortError') // catch error when waitForRequests is aborted
+      } catch (e: any) {
+        if (e.message.includes('been closed') || e.message === 'AbortError')
           resolve();
         else
           reject(e);
       }
-    }).catch(e => {
-      browser.browser()?.close();
-      throw e;
     });
-    return (new Promise((resolve, reject) => {
-      page.route('**/api/generate/v2/**', async (route: any) => {
-        try {
-          logger.info('hCaptcha token received. Closing browser');
-          route.abort();
-          browser.browser()?.close();
-          controller.abort();
-          const request = route.request();
-          this.currentToken = request.headers().authorization.split('Bearer ').pop();
-          resolve(request.postDataJSON().token);
-        } catch(err) {
-          reject(err);
-        }
-      });
-    }));
+
+    // Wire captcha solver errors into the token promise
+    captchaSolverPromise.catch(e => {
+      browser.browser()?.close();
+      rejectOuter(e);
+    });
+
+    // Prevent unhandled rejection on the solver promise
+    captchaSolverPromise.catch(() => {});
+
+    return tokenPromise;
   }
 
   /**
@@ -557,7 +866,14 @@ class SunoApi {
     continue_clip_id?: string,
     continue_at?: number
   ): Promise<AudioInfo[]> {
-    await this.keepAlive();
+    const reqId = ++this.requestCounter;
+    const release = await this.requestSemaphore.acquire();
+    logger.info(
+      `[req-${reqId}] Acquired slot (active: ${this.requestSemaphore.activeCount}, waiting: ${this.requestSemaphore.waitingCount})`
+    );
+
+    try {
+      await this.keepAlive();
     const payload: any = {
       make_instrumental: make_instrumental,
       mv: model || DEFAULT_MODEL,
@@ -577,7 +893,7 @@ class SunoApi {
       payload.gpt_description_prompt = prompt;
     }
     logger.info(
-      'generateSongs payload:\n' +
+      `[req-${reqId}] generateSongs payload:\n` +
         JSON.stringify(
           {
             prompt: prompt,
@@ -641,6 +957,10 @@ class SunoApi {
         negative_tags: audio.metadata.negative_tags,
         duration: audio.metadata.duration
       }));
+    }
+    } finally {
+      logger.info(`[req-${reqId}] Released slot`);
+      release();
     }
   }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -15,8 +15,9 @@ export const sleep = (x: number, y?: number): Promise<void> => {
     const max = Math.max(x, y);
     timeout = Math.floor(Math.random() * (max - min + 1) + min) * 1000;
   }
-  // console.log(`Sleeping for ${timeout / 1000} seconds`);
-  logger.info(`Sleeping for ${timeout / 1000} seconds`);
+  // Only log sleeps >= 1 second to avoid spam from polling loops
+  if (timeout >= 1000)
+    logger.info(`Sleeping for ${timeout / 1000} seconds`);
 
   return new Promise(resolve => setTimeout(resolve, timeout));
 }
@@ -30,14 +31,26 @@ export const isPage = (target: any): target is Page => {
 }
 
 /**
- * Waits for an hCaptcha image requests and then waits for all of them to end
+ * Waits for CAPTCHA-related image/resource requests and then waits for all of them to end.
+ * Detects hCaptcha, reCAPTCHA, Turnstile, and Arkose/FunCaptcha request patterns.
  * @param page
- * @param signal `const controller = new AbortController(); controller.status`
+ * @param signal `const controller = new AbortController(); controller.signal`
  * @returns {Promise<void>} 
  */
 export const waitForRequests = (page: Page, signal: AbortSignal): Promise<void> => {
   return new Promise((resolve, reject) => {
-    const urlPattern = /^https:\/\/img[a-zA-Z0-9]*\.hcaptcha\.com\/.*$/;
+    // Match any CAPTCHA provider's image/resource requests
+    const urlPatterns = [
+      /^https:\/\/img[a-zA-Z0-9]*\.hcaptcha\.com\/.*$/,       // hCaptcha images
+      /^https:\/\/.*\.hcaptcha\.com\/captcha\/.*$/,            // hCaptcha API
+      /^https:\/\/www\.google\.com\/recaptcha\/.*$/,           // reCAPTCHA
+      /^https:\/\/www\.gstatic\.com\/recaptcha\/.*$/,          // reCAPTCHA assets
+      /^https:\/\/challenges\.cloudflare\.com\/.*$/,           // Cloudflare Turnstile
+      /^https:\/\/.*\.arkoselabs\.com\/.*$/,                   // Arkose/FunCaptcha
+    ];
+
+    const matchesCaptchaUrl = (url: string) => urlPatterns.some(p => p.test(url));
+
     let timeoutHandle: NodeJS.Timeout | null = null;
     let activeRequestCount = 0;
     let requestOccurred = false;
@@ -60,7 +73,7 @@ export const waitForRequests = (page: Page, signal: AbortSignal): Promise<void> 
     };
 
     const onRequest = (request: { url: () => string }) => {
-      if (urlPattern.test(request.url())) {
+      if (matchesCaptchaUrl(request.url())) {
         requestOccurred = true;
         activeRequestCount++;
         if (timeoutHandle)
@@ -69,31 +82,31 @@ export const waitForRequests = (page: Page, signal: AbortSignal): Promise<void> 
     };
 
     const onRequestFinished = (request: { url: () => string }) => {
-      if (urlPattern.test(request.url())) {
+      if (matchesCaptchaUrl(request.url())) {
         activeRequestCount--;
         resetTimeout();
       }
     };
 
-    // Wait for an hCaptcha request for up to 1 minute
+    // Wait for a CAPTCHA request for up to 2 minutes
     const initialTimeout = setTimeout(() => {
       if (!requestOccurred) {
         page.off('request', onRequest);
         cleanupListeners();
-        reject(new Error('No hCaptcha request occurred within 1 minute.'));
+        reject(new Error('No CAPTCHA image/resource requests detected within 2 minutes.'));
       } else {
-        // Start waiting for no hCaptcha requests
+        // Start waiting for no CAPTCHA requests
         resetTimeout();
       }
-    }, 60000); // 1 minute timeout
+    }, 120000); // 2 minute timeout
 
     page.on('request', onRequest);
     page.on('requestfinished', onRequestFinished);
     page.on('requestfailed', onRequestFinished);
 
-    // Cleanup the initial timeout if an hCaptcha request occurs
+    // Cleanup the initial timeout if a CAPTCHA request occurs
     page.on('request', (request: { url: () => string }) => {
-      if (urlPattern.test(request.url())) {
+      if (matchesCaptchaUrl(request.url())) {
         clearTimeout(initialTimeout);
       }
     });
@@ -115,4 +128,82 @@ export const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
   'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+}
+
+/**
+ * A simple async mutex. Only one holder at a time; others queue up.
+ * Usage:
+ *   const release = await mutex.acquire();
+ *   try { ... } finally { release(); }
+ */
+export class AsyncMutex {
+  private queue: Array<(release: () => void) => void> = [];
+  private locked = false;
+
+  async acquire(): Promise<() => void> {
+    if (!this.locked) {
+      this.locked = true;
+      return () => this.release();
+    }
+    return new Promise<() => void>((resolve) => {
+      this.queue.push((release) => resolve(release));
+    });
+  }
+
+  private release(): void {
+    if (this.queue.length > 0) {
+      const next = this.queue.shift()!;
+      next(() => this.release());
+    } else {
+      this.locked = false;
+    }
+  }
+
+  get isLocked(): boolean {
+    return this.locked;
+  }
+
+  get queueLength(): number {
+    return this.queue.length;
+  }
+}
+
+/**
+ * An async semaphore that allows up to `maxConcurrency` holders at a time.
+ * Usage:
+ *   const release = await semaphore.acquire();
+ *   try { ... } finally { release(); }
+ */
+export class AsyncSemaphore {
+  private currentCount = 0;
+  private queue: Array<(release: () => void) => void> = [];
+
+  constructor(private maxConcurrency: number) {}
+
+  async acquire(): Promise<() => void> {
+    if (this.currentCount < this.maxConcurrency) {
+      this.currentCount++;
+      return () => this.release();
+    }
+    return new Promise<() => void>((resolve) => {
+      this.queue.push((release) => resolve(release));
+    });
+  }
+
+  private release(): void {
+    this.currentCount--;
+    if (this.queue.length > 0) {
+      this.currentCount++;
+      const next = this.queue.shift()!;
+      next(() => this.release());
+    }
+  }
+
+  get activeCount(): number {
+    return this.currentCount;
+  }
+
+  get waitingCount(): number {
+    return this.queue.length;
+  }
 }


### PR DESCRIPTION
## Summary

This PR addresses two major issues with the current codebase:

1. **CAPTCHA handling is broken** — Suno changed their UI, causing hardcoded selectors (`.custom-textarea`) to fail with `TimeoutError`.
2. **No concurrency support** — Concurrent API requests race on shared state (token refresh, browser sessions), causing crashes and wasted resources.

---

## Changes

### 1. CAPTCHA Handling Rewrite (v2)

**Problem:** The Suno website UI changed, breaking the existing CAPTCHA flow. The hardcoded `.custom-textarea` selector no longer exists, causing `TimeoutError: Timeout 30000ms exceeded`.

**Solution:**

- **Fallback selectors**: 10 selectors for prompt input, 8 for Create button — resilient against UI changes
- **Debug snapshot system**: Saves HTML, screenshots, request logs, frame lists, and interactive element enumeration into a `debug/` folder at every step
- **Multi-CAPTCHA provider detection**: Detects hCaptcha, reCAPTCHA, Cloudflare Turnstile, and Arkose/FunCaptcha
- **Popup auto-dismissal**: Closes modals/banners before interacting with the page
- **Retry logic**: Retries Create button click if CAPTCHA doesn't appear on first attempt
- **Race condition fix**: Sets up route interception before clicking Create, so token is never missed
- **Error propagation fix**: Captcha solver errors are properly wired to the outer promise (no more unhandled rejections)

### 2. Async Concurrency Support

**Problem:** When multiple requests hit the API simultaneously, they all race on `keepAlive()` token refresh and `getCaptcha()` browser launches.

**Solution:**

- **`AsyncMutex`** — Serializes `keepAlive()` token refresh and `getCaptcha()` browser sessions
- **`AsyncSemaphore`** — Limits concurrent generation requests (configurable via `CONCURRENT_LIMIT` env var, default: 3)
- **Token refresh cooldown** — `keepAlive()` skips refresh if token was refreshed within 30 seconds
- **Request ID tracking** — Each request gets `[req-N]` prefix in logs for traceability
- **Double-check pattern** — After acquiring CAPTCHA mutex, re-checks if CAPTCHA is still needed

### 3. Utility Improvements (`utils.ts`)

- `sleep()` no longer logs calls < 1 second (eliminates polling log spam)
- `waitForRequests()` detects 6 URL patterns across 4 CAPTCHA providers
- Timeout increased from 60s to 120s

---

## Configuration

New optional env variable:

```env
# Max concurrent generation requests (default: 3)
CONCURRENT_LIMIT=3
```

## Testing

- TypeScript: No type errors
- ESLint: No warnings or errors
- Tested with concurrent `/api/custom_generate` requests — token refresh is serialized, CAPTCHA solving is serialized, generation requests are semaphore-limited

## Files Changed

- `src/lib/utils.ts` — AsyncMutex, AsyncSemaphore, multi-provider CAPTCHA detection, sleep log fix
- `src/lib/SunoApi.ts` — getCaptcha v2 rewrite, concurrency primitives integration